### PR TITLE
ci: migrate issue workflows to owner-replied/user-replied

### DIFF
--- a/.github/workflows/issue-timeout.yml
+++ b/.github/workflows/issue-timeout.yml
@@ -1,0 +1,91 @@
+name: Issue — Auto-close on No Response
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+
+jobs:
+  close-unresponded:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Close issues with owner-replied but no user follow-up after 24h
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const now = Date.now();
+            const twentyFourHours = 24 * 60 * 60 * 1000;
+
+            const issues = await github.paginate(
+              github.rest.issues.listForRepo,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                labels: 'owner-replied',
+                per_page: 100
+              }
+            );
+
+            for (const issue of issues) {
+              if (issue.pull_request) continue;
+
+              const comments = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                per_page: 100
+              });
+
+              // Find when owner last replied
+              const ownerAssociations = ['OWNER', 'MEMBER', 'COLLABORATOR'];
+              const ownerComments = comments.data.filter(c =>
+                ownerAssociations.includes(c.author_association) && c.user.type !== 'Bot'
+              );
+              if (ownerComments.length === 0) continue;
+
+              const lastOwnerReply = Math.max(...ownerComments.map(c => new Date(c.created_at).getTime()));
+              const age = now - lastOwnerReply;
+              if (age < twentyFourHours) continue;
+
+              // Check if user replied after the owner's last comment
+              const author = issue.user.login;
+              const userRepliedAfter = comments.data.some(c =>
+                c.user.login === author &&
+                new Date(c.created_at).getTime() > lastOwnerReply
+              );
+              if (userRepliedAfter) continue;
+
+              const closeBody = [
+                `Hey @${author} — this issue has been automatically closed because there was no follow-up within **24 hours** of the last response.`,
+                ``,
+                `This is not a rejection. If you still have the problem, please **reopen this issue** and include:`,
+                ``,
+                `- The relevant lines from your \`log.txt\``,
+                `  - Location: \`Documents/My Games/FarmingSimulator2025/log.txt\``,
+                `- Your mod version (visible in the mod manager)`,
+                `- Steps to reproduce the issue`,
+                ``,
+                `We look forward to helping you once we have the details!`,
+              ].join('\n');
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: closeBody
+              });
+
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: 'not_planned'
+              });
+
+              core.info(`Closed issue #${issue.number} — no user follow-up after owner replied`);
+            }

--- a/.github/workflows/issue-welcome.yml
+++ b/.github/workflows/issue-welcome.yml
@@ -1,0 +1,54 @@
+name: Issue — Welcome & Label
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  welcome:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Apply user-replied label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['user-replied']
+            });
+
+      - name: Post welcome comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const author = context.payload.issue.user.login;
+            const repoName = context.repo.repo;
+            const modName = repoName.replace('FS25_', '').replace(/([A-Z])/g, ' $1').trim();
+
+            const body = [
+              `Hey @${author}, thanks for opening this issue! 👋`,
+              ``,
+              `@TheCodingDad-TisonK has been notified and will take a look as soon as possible.`,
+              ``,
+              `**While you wait, please double-check the following:**`,
+              ``,
+              `- [ ] You are running the latest version of ${modName} (visible in the mod manager)`,
+              `- [ ] Your issue includes relevant lines from \`log.txt\``,
+              `  - Log location: \`Documents/My Games/FarmingSimulator2025/log.txt\``,
+              `  - Search for \`[${modName}]\` — paste the relevant section in your issue`,
+              `- [ ] You have searched [existing issues](https://github.com/${context.repo.owner}/${repoName}/issues) for a similar report`,
+              ``,
+              `> **Important:** If this issue is missing a log snippet, it may be closed without investigation. A log is almost always required to reproduce bugs.`,
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body
+            });


### PR DESCRIPTION
Replaces the old `waiting-on-author` label system with `owner-replied` / `user-replied`.

**Changes:**
- `issue-welcome.yml` — applies `user-replied` on new issue open, cleans up welcome message
- `issue-timeout.yml` — now closes issues where owner replied but user didn't follow up in 24h (was: waiting-on-author timeout)
- `issue-author-responded.yml` — **deleted**, superseded by `reply-labels.yml`