### PR TITLE
fix: MP settings persistence, farm-scoped shift HUD, radius tuning

### DIFF
--- a/src/WorkplaceMultiplayerEvent.lua
+++ b/src/WorkplaceMultiplayerEvent.lua
@@ -163,7 +163,8 @@ function WorkplaceMultiplayerEvent:handleShiftStart(sys, connection)
                   earnings       = 0,
                   hourlyWage     = trigger.hourlyWage     or 500,
                   paySchedule    = trigger.paySchedule    or "hourly",
-                  timeMultiplier = trigger.timeMultiplier or 0 }
+                  timeMultiplier = trigger.timeMultiplier or 0,
+                  farmId         = self.farmId or 1 }
             ))
         else
             wtLog("Server: shift start rejected - trigger not found: " .. tostring(self.triggerId))
@@ -200,7 +201,8 @@ function WorkplaceMultiplayerEvent:handleShiftEnd(sys, connection)
             end
             g_server:broadcastEvent(WorkplaceMultiplayerEvent.new(
                 WorkplaceMultiplayerEvent.TYPE_SHIFT_CONFIRM,
-                { triggerId = "", workplaceName = name or "", earnings = earned }
+                { triggerId = "", workplaceName = name or "", earnings = earned,
+                  farmId = sys.shiftTracker.activeFarmId or 1 }
             ))
         end
     end
@@ -214,8 +216,14 @@ function WorkplaceMultiplayerEvent:handleShiftConfirm(sys)
     -- misread the end-confirm as a start-confirm and leave the shift stuck active.
     local isEnd = (self.triggerId == "")
 
-    -- This is the ONLY place client HUDs update for shift events
-    if sys.hud then
+    -- Determine if this confirm belongs to the local player's farm.
+    -- Only the owning farm sees the HUD update; others ignore it.
+    local confirmFarmId = self.farmId or 1
+    local localFarmId   = (g_currentMission and g_currentMission:getFarmId()) or 1
+    local isOwner       = (confirmFarmId == localFarmId)
+
+    -- Only update HUD for the client that owns this shift
+    if sys.hud and isOwner then
         if isEnd then
             sys.hud:onShiftEnded(self.workplaceName, self.earnings)
         else
@@ -238,7 +246,9 @@ function WorkplaceMultiplayerEvent:handleShiftConfirm(sys)
             sys.shiftTracker.leaveWarnActive     = false
             sys.shiftTracker.leaveWarnTimer      = 0
         else
-            -- Shift started: populate tracker so updateZoneCheck works client-side
+            -- Shift started: populate tracker so updateZoneCheck works client-side.
+            -- shiftOwnerIsLocal controls whether this client runs zone checks —
+            -- only the owning farm should trigger zone violations.
             sys.shiftTracker.activeTriggerId     = self.triggerId
             sys.shiftTracker.activeWorkplaceName = self.workplaceName
             sys.shiftTracker.activeHourlyWage    = self.hourlyWage
@@ -248,6 +258,7 @@ function WorkplaceMultiplayerEvent:handleShiftConfirm(sys)
             sys.shiftTracker.shiftElapsedMs      = 0
             sys.shiftTracker.leaveWarnActive     = false
             sys.shiftTracker.leaveWarnTimer      = 0
+            sys.shiftTracker.shiftOwnerIsLocal   = isOwner
         end
     end
 

--- a/src/WorkplaceSettingsIntegration.lua
+++ b/src/WorkplaceSettingsIntegration.lua
@@ -257,8 +257,10 @@ local function apply(key, value, msg)
     local s = getSettings()
     if not s then return end
     s[key] = value
-    -- Persist next full save; no immediate disk write needed (UsedPlus pattern)
     if msg then wtLog(msg) end
+    -- Write immediately so changes survive a restart without an explicit game save
+    local mi = g_currentMission and g_currentMission.missionInfo
+    if mi then s:saveToXMLFile(mi) end
 end
 
 function WorkplaceSettingsIntegration:onShowHudChanged(state)


### PR DESCRIPTION
## Summary

- **Settings persist immediately** — toggles (e.g. End Shift on Leave) no longer reset on restart; `saveToXMLFile()` is now called on every settings change instead of waiting for a full game save
- **Shift HUD scoped to owning farm** — `TYPE_SHIFT_CONFIRM` now carries `farmId`; non-owner clients skip the HUD update and zone checks (`shiftOwnerIsLocal` set correctly)
- **Trigger radius raised** — max 300 m, step 5 m (was 50 m max)
- **SHIFT_CONFIRM broadcast fix** — hourlyWage and paySchedule were missing from the confirm message; clients now receive correct pay data
- **MP trigger sync fixes** — farm ID payout routing, time multiplier selector, dedicated server trigger sync

## Test plan
- [ ] Toggle "End Shift on Leave", restart game — verify toggle is preserved
- [ ] MP: player A starts shift — verify only player A sees the HUD notification
- [ ] MP: player B in same session — verify no HUD shown, no zone penalties
- [ ] Create trigger with radius > 50 m — verify accepted up to 300 m
- [ ] Dedicated server: triggers persist and sync on rejoin