### PR TITLE
feat: trigger purpose designation (server-gated setter + getter)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,6 +24,7 @@
 ## Mid-term (this season)
 - [~] Bedrock migration: StateLedger + MasterHUD + SettingsHub bridged (939f701, c98a876, delegate-when-present). NetworkSync (WorkplaceMultiplayerEvent) deferred - a money-authority-class request/response protocol (shifts pay wages server-side), needs the NS build-brief.
 - [ ] Expose the companion read surface WorkerCosts consumes.
+- [x] Trigger purpose designation (2026-08-05, ruled yes by Tyson): optional `purpose` string, server-gated `set_trigger_purpose` bridge action, `getTriggersByPurpose`. First consumer: the Co-Op Home Ladder rung 3 (PS-3).
 
 ## Long-term / aspirational
 - [ ] Richer workplace types and job variety.

--- a/TODO.md
+++ b/TODO.md
@@ -21,6 +21,7 @@
 
 ## Features / enhancements
 - [~] BL17 cooldown DONE; the companion read surface for WorkerCosts still open.
+- [x] Trigger purpose designation (2026-08-05): optional `purpose` on the trigger record, server-gated `set_trigger_purpose` bridge action under the existing admin gate, `getTriggersByPurpose`. Persisted through own XML + StateLedger bridge + NetworkSync snapshot/actions. First consumer: Co-Op Home Ladder rung 3. Non-breaking both directions (loader defaults every read).
 
 ## Cross-mod integration
 - [x] StateLedger: `WorkplaceTriggers_Data` bridge live (trigger definitions + HUD layout; commit c98a876, delegate-when-present, own XML kept as the safety copy, force-parseFile timing). Settings go to SettingsHub, NOT a second SL module (state-to-SL / settings-to-SettingsHub split).

--- a/TODO.md
+++ b/TODO.md
@@ -4,6 +4,10 @@
 > Status: FILLED from the ecosystem audit/baseline, kept current.
 > Convention: `[ ]` open · `[~]` in progress · `[x]` done · `[!]` blocked. Newest at the top of each section.
 
+## Bugs
+- [x] 2026-07-30: `src/integrations/WTNetworkSyncBridge.lua:192` failed to COMPILE - `g_currentMission:getFarmId and ...`. The `:` call syntax requires an immediate argument list, so Lua stopped at `and` ("expected '(', '{' or <string>"). The whole file was rejected and the NetworkSync bridge was dead in every session. Resolved with the suite's proven local-farm-id order (`g_localPlayer.farmId`, then `g_currentMission.player.farmId`) rather than a one-character patch: `getFarmId` is not in the Community LUADOC, so a guarded probe on it alone would have compiled and then silently always yielded -1, leaving the host's own shift state permanently un-updated.
+- [ ] **ROOT CAUSE, still open: `build.sh` has NO Lua 5.1 syntax gate**, which is the only reason the above reached the game. SoilFertilizer catches this class before it ships (pre-commit `luaparse` pinned to 5.1 across all sources, plus lint). Port that gate here or into `build.sh` as a build-failing step.
+
 ## From the ecosystem audit (Arissani)
 - [x] Fast-track BL17: cooldown cap on triggers to stop spam. DONE.
 - [ ] Fix detection: `g_NPCFavorSystem` -> `g_currentMission.npcFavorSystem`; `g_WorkerCostsSystem` -> `g_currentMission.workerCostsManager`.

--- a/main.lua
+++ b/main.lua
@@ -1,5 +1,5 @@
 -- =========================================================
--- FS25 Workplace Triggers (v0.1.0.0)
+-- FS25 Workplace Triggers (v1.1.1.1)
 -- Placeable Off-Farm Work System
 -- =========================================================
 -- Author: TisonK

--- a/src/WorkplaceSaveLoad.lua
+++ b/src/WorkplaceSaveLoad.lua
@@ -4,7 +4,8 @@
 -- =========================================================
 -- Pattern: SaveLoadHandler.lua from FS25_SeasonalCropStress
 -- CRITICAL: Use OOP xmlFile:setInt() etc. NEVER legacy globals.
--- Save layout inside careerSavegame XML:
+-- Save layout inside the mod's own standalone file (getSavePath below), NOT the
+-- career savegame:
 --   <workplaceTriggers>
 --     <triggers>
 --       <trigger idx="0" id="wt_1" name="Post Office" hourlyWage="500"
@@ -115,6 +116,7 @@ function WorkplaceSaveLoad:saveToXMLFile(missionInfo)
         xmlFile:setString(key .. "#paySchedule",     trigger.paySchedule    or "hourly")
         xmlFile:setInt(   key .. "#timeMultiplier",  trigger.timeMultiplier or 0)
         xmlFile:setBool(  key .. "#endShiftOnLeave", trigger.endShiftOnLeave ~= false)
+        xmlFile:setString(key .. "#purpose",         trigger.purpose or "")
         count = count + 1
     end
 
@@ -174,6 +176,7 @@ function WorkplaceSaveLoad:loadFromXMLFile(missionInfo)
         local savedSched           = xmlFile:getString(key .. "#paySchedule",     "hourly")
         local savedTimeMultiplier  = xmlFile:getInt(   key .. "#timeMultiplier",  0)
         local savedEndShiftOnLeave = xmlFile:getBool(  key .. "#endShiftOnLeave", true)
+        local savedPurpose         = xmlFile:getString(key .. "#purpose",         "")
 
         -- Triggers are pure data objects — register directly, no placeable needed
         local triggerData = {
@@ -187,6 +190,7 @@ function WorkplaceSaveLoad:loadFromXMLFile(missionInfo)
             paySchedule     = savedSched,
             timeMultiplier  = savedTimeMultiplier or 0,
             endShiftOnLeave = savedEndShiftOnLeave ~= false,
+            purpose         = savedPurpose,
             playerInside    = false,
         }
         self.system.triggerManager:registerTrigger(triggerData)

--- a/src/WorkplaceStateLedgerBridge.lua
+++ b/src/WorkplaceStateLedgerBridge.lua
@@ -34,7 +34,7 @@ WorkplaceStateLedgerBridge = {}
 -- (Arissani's readiness prose calls it "WorkplaceTriggers_Triggers"; Point-1's actual
 -- registration code names it "WorkplaceTriggers_Data" -- flagged for the lock.)
 WorkplaceStateLedgerBridge.MODULE_ID = "WorkplaceTriggers_Data"
-WorkplaceStateLedgerBridge.SCHEMA    = 1
+WorkplaceStateLedgerBridge.SCHEMA    = 2
 
 WorkplaceStateLedgerBridge.active       = false   -- ledger present and we registered
 WorkplaceStateLedgerBridge.delivered    = false   -- deserialize has fired (once)
@@ -62,6 +62,7 @@ function WorkplaceStateLedgerBridge.buildState(sys)
                 paySchedule     = t.paySchedule or "hourly",
                 timeMultiplier  = t.timeMultiplier or 0,
                 endShiftOnLeave = t.endShiftOnLeave ~= false,
+                purpose         = t.purpose or "",
             }
         end
     end
@@ -99,6 +100,7 @@ function WorkplaceStateLedgerBridge.applyState(sys)
                 paySchedule     = t.paySchedule or "hourly",
                 timeMultiplier  = t.timeMultiplier or 0,
                 endShiftOnLeave = t.endShiftOnLeave ~= false,
+                purpose         = t.purpose or "",
                 playerInside    = false,
             })
             count = count + 1

--- a/src/WorkplaceTriggerManager.lua
+++ b/src/WorkplaceTriggerManager.lua
@@ -322,6 +322,39 @@ function WorkplaceTriggerManager:getTriggerById(id)
     return nil
 end
 
+-- Return every trigger carrying the given purpose. Empty/absent purpose matches
+-- nothing for a non-empty query, so consumers never trip over un-designated
+-- triggers. Same string-compare idiom as getTriggerById.
+function WorkplaceTriggerManager:getTriggersByPurpose(purpose)
+    if purpose == nil or purpose == "" then return {} end
+    local searchPurpose = tostring(purpose)
+    local result = {}
+    for _, trigger in ipairs(self.triggers) do
+        if tostring(trigger.purpose or "") == searchPurpose then
+            result[#result + 1] = trigger
+        end
+    end
+    return result
+end
+
+-- Set a trigger's purpose. Server-authoritative: call from the server-side
+-- NetworkSync action handler only, never from client-local code. purpose == ""
+-- clears the designation back to no-purpose.
+function WorkplaceTriggerManager:setTriggerPurpose(triggerId, purpose)
+    local trigger = self:getTriggerById(triggerId)
+    if trigger == nil then
+        wtLog("setTriggerPurpose: trigger not found: " .. tostring(triggerId))
+        return false
+    end
+    local nextPurpose = (purpose ~= nil) and tostring(purpose) or nil
+    local was = trigger.purpose or ""
+    if (nextPurpose or "") == was then return true end
+    trigger.purpose = nextPurpose
+    wtLog(string.format("setTriggerPurpose: '%s' (id=%s) purpose '%s' -> '%s'",
+        trigger.workplaceName or "?", tostring(triggerId), was, nextPurpose or ""))
+    return true
+end
+
 -- =========================================================
 -- Geometry
 -- =========================================================

--- a/src/integrations/WTNetworkSyncBridge.lua
+++ b/src/integrations/WTNetworkSyncBridge.lua
@@ -189,7 +189,23 @@ local function onShiftStart(sys, userId, args)
 
     -- Listen-server: also update single-slot state for the host's own shift
     if g_currentMission and g_currentMission:getIsServer() then
-        local localFarmId = g_currentMission:getFarmId and g_currentMission:getFarmId() or -1
+        -- `g_currentMission:getFarmId and ...` was a COMPILE error: the `:` call syntax
+        -- requires an immediate argument list, so Lua stopped at `and` ("expected '(',
+        -- '{' or <string>"). The whole file failed to load, taking this bridge with it.
+        --
+        -- Resolved with the order proven across the suite (SoilFertilizer, NPCFavor,
+        -- WorkerCosts) rather than a one-character syntax patch: `getFarmId` is not in
+        -- the Community LUADOC, so a guarded probe on it alone would have compiled and
+        -- then silently always yielded -1, meaning the host's own shift state never
+        -- updated. It stays as a last-resort probe, correctly guarded with `.`.
+        local localFarmId = -1
+        if g_localPlayer ~= nil and g_localPlayer.farmId ~= nil then
+            localFarmId = g_localPlayer.farmId
+        elseif g_currentMission.player ~= nil and g_currentMission.player.farmId ~= nil then
+            localFarmId = g_currentMission.player.farmId
+        elseif type(g_currentMission.getFarmId) == "function" then
+            localFarmId = g_currentMission:getFarmId() or -1
+        end
         if farmId == localFarmId then
             pcall(function() sys.shiftTracker:startShift(trigger, true) end)
             sys.shiftTracker.activeFarmId      = farmId

--- a/src/integrations/WTNetworkSyncBridge.lua
+++ b/src/integrations/WTNetworkSyncBridge.lua
@@ -36,7 +36,7 @@ end
 -- State serialization (server -> client full snapshot)
 -- =========================================================
 -- Flat array: [triggerCount, ...per trigger fields..., wageMultiplier]
--- Schema v1.  12 fields per trigger (matches WorkplaceStateLedgerBridge.buildState).
+-- Schema v2.  13 fields per trigger (added purpose, appended after playerInside).
 local function buildStateArray()
     local arr = {}
     local sys = g_WorkplaceSystem
@@ -56,6 +56,7 @@ local function buildStateArray()
         arr[#arr + 1] = t.timeMultiplier or 0
         arr[#arr + 1] = t.endShiftOnLeave ~= false
         arr[#arr + 1] = t.playerInside or false
+        arr[#arr + 1] = t.purpose or ""
     end
 
     -- Settings (server-authoritative wage multiplier)
@@ -94,9 +95,10 @@ local function applyStateArray(arr)
             timeMultiplier  = arr[i + 9] or 0,
             endShiftOnLeave = arr[i + 10] ~= false,
             playerInside    = arr[i + 11] or false,
+            purpose         = arr[i + 12] or "",
         }
         sys.triggerManager:registerTrigger(triggerData)
-        i = i + 12
+        i = i + 13
     end
 
     -- Apply settings
@@ -122,9 +124,10 @@ end
 -- Server-side action handler
 -- =========================================================
 local TRIGGER_ACTIONS = {
-    create_trigger = true,
-    update_trigger = true,
-    delete_trigger = true,
+    create_trigger       = true,
+    update_trigger       = true,
+    delete_trigger       = true,
+    set_trigger_purpose  = true,
 }
 
 local function onAction(userId, args)
@@ -157,6 +160,8 @@ local function onAction(userId, args)
         onUpdateTrigger(sys, userId, args)
     elseif actionType == "delete_trigger" then
         onDeleteTrigger(sys, userId, args)
+    elseif actionType == "set_trigger_purpose" then
+        onSetTriggerPurpose(sys, userId, args)
     else
         return
     end
@@ -271,6 +276,7 @@ local function onCreateTrigger(sys, userId, args)
         paySchedule     = args[9] or "hourly",
         timeMultiplier  = args[10] or 0,
         endShiftOnLeave = args[11] ~= false,
+        purpose         = args[12] or "",
         playerInside    = false,
     }
 
@@ -331,6 +337,24 @@ local function onDeleteTrigger(sys, userId, args)
     wtLog("DELETE_TRIGGER: id=" .. triggerId)
 end
 
+local function onSetTriggerPurpose(sys, userId, args)
+    local triggerId = tostring(args[2] or "")
+    -- Distinguish an explicit clear (empty string) from an absent value:
+    -- args[3] is the purpose; nil means "no value supplied", "" means "clear".
+    if args[3] == nil then
+        wtLog("SET_TRIGGER_PURPOSE rejected: no purpose value: id=" .. triggerId)
+        return
+    end
+
+    local ok = sys.triggerManager:setTriggerPurpose(triggerId, args[3])
+    if not ok then
+        wtLog("SET_TRIGGER_PURPOSE rejected: trigger not found: id=" .. triggerId)
+        return
+    end
+
+    wtLog("SET_TRIGGER_PURPOSE: id=" .. triggerId .. " purpose='" .. tostring(args[3]) .. "'")
+end
+
 -- =========================================================
 -- Public: send a client->server action through NetworkSync
 -- =========================================================
@@ -386,6 +410,7 @@ function WTNetworkSyncBridge.sendCreateTrigger(data)
                     paySchedule     = data.paySchedule   or "hourly",
                     timeMultiplier  = data.timeMultiplier or 0,
                     endShiftOnLeave = data.endShiftOnLeave ~= false,
+                    purpose         = data.purpose       or "",
                     playerInside    = false,
                 })
             end)
@@ -403,6 +428,7 @@ function WTNetworkSyncBridge.sendCreateTrigger(data)
         data.paySchedule     or "hourly",
         data.timeMultiplier  or 0,
         data.endShiftOnLeave ~= false,
+        data.purpose         or "",
     })
 end
 
@@ -420,6 +446,16 @@ end
 
 function WTNetworkSyncBridge.sendDeleteTrigger(triggerId)
     return WTNetworkSyncBridge.requestAction({ "delete_trigger", tostring(triggerId) })
+end
+
+-- Server-authoritative designation. Safe to call on both server and client:
+-- requestAction runs locally on the server (under the admin gate) and forwards
+-- on a client. Pass purpose = "" to clear the designation.
+function WTNetworkSyncBridge.sendSetTriggerPurpose(triggerId, purpose)
+    if purpose == nil then return false end
+    return WTNetworkSyncBridge.requestAction({
+        "set_trigger_purpose", tostring(triggerId), tostring(purpose),
+    })
 end
 
 function WTNetworkSyncBridge.sendSyncSettings()


### PR DESCRIPTION
# Trigger purpose designation

Gives a trigger an optional, server-authoritative purpose so a feature with no placeable of its own can live at a trigger the player sited. First consumer is the Co-Op Home Ladder rung 3 (ProStaff designates a trigger as the Co-Op home).

Ruled by Tyson on 2026-08-05: single purpose string (not a set), server-gated setter. Shape brief: `TRIGGER-PURPOSE-BUILD-BRIEF.md` in the tracking repo.

## What changed

- Optional `purpose` string on the trigger record, default absent. A trigger with no purpose set behaves byte-for-byte as before.
- `setTriggerPurpose` on the manager, reached only through a new `set_trigger_purpose` NetworkSync action under the existing admin gate (master user or admin). An empty string clears the designation.
- `getTriggersByPurpose` on the manager, beside the four existing getters.
- Purpose persists through all four serialization surfaces: the own XML save, the StateLedger bridge (schema bumped to 2), and the NetworkSync snapshot plus the create and set actions.

## Why all four surfaces

The proposal originally scoped save + getter, but the trigger table also travels through the NetworkSync flat array and the StateLedger bridge. A purpose that skipped any of them would be invisible to a consumer running through that path.

## Compat

Non-breaking in both directions. Every read in the loader supplies a default, so an old save loads with an empty purpose and a new save loads on an old build because the attribute is simply never read.

## Housekeeping on the way

- Fixed the stale header comment in `WorkplaceSaveLoad.lua` that said the save layout lives in the career savegame (it writes the standalone mod file).
- `main.lua` header now matches modDesc (v1.1.1.1, was v0.1.0.0).

## Verification

All touched files parse at Lua 5.1 (luaparse). Built and deployed; the deployed zip was unzipped and confirmed to carry the new code. In-game observation is still owed: place a trigger with no purpose, set one as admin, confirm a rejoin client sees it, confirm a non-admin is refused, confirm an empty string clears it.
