### PR TITLE
chore(workplace): leftover MasterHUD bridge

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -180,7 +180,9 @@ if FSBaseMission and FSBaseMission.draw then
         -- registered as a self-draw via the bridge); stand down so the HUD never
         -- draws twice. Absent MasterHUD, this hook runs the draw as before.
         if WorkplaceMasterHUDBridge ~= nil and WorkplaceMasterHUDBridge.active then return end
-        if workplaceSystem then
+        if WorkplaceMasterHUDBridge ~= nil then
+            WorkplaceMasterHUDBridge.drawStack()
+        elseif workplaceSystem then
             workplaceSystem:draw()
         end
     end)

--- a/src/WorkplaceMasterHUDBridge.lua
+++ b/src/WorkplaceMasterHUDBridge.lua
@@ -30,6 +30,9 @@ end
 -- The WT HUD draw body. Same call the standalone FSBaseMission.draw hook makes;
 -- WorkplaceSystem:draw() self-guards on isInitialized and the HUD on client.
 function WorkplaceMasterHUDBridge.drawStack()
+    -- Suite hide: MasterHUD # key. No-op when MasterHUD absent.
+    local mh = (g_currentMission ~= nil and g_currentMission.masterHUD) or g_masterHUD
+    if mh ~= nil and mh.areHudsHidden ~= nil and mh:areHudsHidden() then return end
     if g_WorkplaceSystem ~= nil then
         g_WorkplaceSystem:draw()
     end
@@ -52,6 +55,23 @@ function WorkplaceMasterHUDBridge.register()
     if ok then
         WorkplaceMasterHUDBridge.active = true
         wtLog("Registered WT HUD with MasterHUD (single draw loop + menu-suspend)")
+        if hud.registerEditListener ~= nil then
+            hud:registerEditListener(WorkplaceMasterHUDBridge.HUD_ID, {
+                enter = function()
+                    local sys = g_WorkplaceSystem
+                    if sys ~= nil and sys.hud ~= nil and sys.hud.enterEditMode ~= nil then
+                        sys.hud:enterEditMode()
+                    end
+                end,
+                exit = function()
+                    local sys = g_WorkplaceSystem
+                    if sys ~= nil and sys.hud ~= nil and sys.hud.editMode
+                        and sys.hud.exitEditMode ~= nil then
+                        sys.hud:exitEditMode()
+                    end
+                end,
+            })
+        end
     else
         wtLog("MasterHUD registration failed: " .. tostring(err) .. " (using own draw hook)")
     end


### PR DESCRIPTION
## Summary
- Local MasterHUD / SettingsHub / companion HUD-bridge leftovers that should have been shared with the Esc wave and were missed.

## Test plan
- [ ] Game loads with this mod
- [ ] No new Can't load resource for this mod
