### PR TITLE
Release v1.1.1.2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,34 @@
 # CLAUDE.md
 
+## Git Workflow — ONE FEATURE, ONE PR
+
+> **Tyson's ruling, 2026-08-10. BINDING on every human and every agent seat, including Bob, Fred and Sasha, because those seats are the ones opening PRs.**
+
+- **Every feature, fix or brief gets its OWN BRANCH**, cut fresh from `development`:
+  `feat/<ID>-<slug>`, `fix/<ID>-<slug>`, or `docs/<slug>` / `chore/<slug>` for non-code work
+  (e.g. `feat/SCS-037-caught-up-hour`).
+  Commit **only that one item** on it.
+- **The PR is `feat/...` → `development`.** One item per PR, always. Delete the branch on merge.
+- **NEVER open a feature PR from `development` itself.** `development` is the trunk: a PR based on it
+  silently absorbs every commit that lands while it is open, under a title that still describes the
+  first one. **This happened twice in two days**, the second time to the seat that had just reported it.
+- **`development` → `main` is a RELEASE PR only**, titled `Release vX.Y.Z`. It may carry many features
+  *by design* and its body lists them. It is never a feature PR.
+- **Never commit or push directly to `main`.** Check your branch at the start of every session.
+- If a PR does end up carrying more than its title says: **retitle, rebody with the full commit list,
+  and refresh every approval.** An old approval never covers code it did not see.
+
+```bash
+git checkout development && git pull
+git checkout -b feat/SCS-037-caught-up-hour
+#   ...commit the ONE feature...
+git push -u origin feat/SCS-037-caught-up-hour
+gh pr create --base development
+#   -> Sasha approves -> Tyson merges -> branch deleted
+```
+
+**Sasha approves, Tyson merges.** No seat both approves and lands the same PR.
+
 ## Project Overview
 FS25_WorkplaceTriggers - Placeable off-farm work triggers for FS25.
 Patterns: NPCFavor (HUD, RVB input, GUI, events) + SeasonalCropStress (save/load, placeables, integrations).

--- a/main.lua
+++ b/main.lua
@@ -180,7 +180,9 @@ if FSBaseMission and FSBaseMission.draw then
         -- registered as a self-draw via the bridge); stand down so the HUD never
         -- draws twice. Absent MasterHUD, this hook runs the draw as before.
         if WorkplaceMasterHUDBridge ~= nil and WorkplaceMasterHUDBridge.active then return end
-        if workplaceSystem then
+        if WorkplaceMasterHUDBridge ~= nil then
+            WorkplaceMasterHUDBridge.drawStack()
+        elseif workplaceSystem then
             workplaceSystem:draw()
         end
     end)

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <modDesc descVersion="106">
     <author>TisonK</author>
-    <version>1.1.1.1</version>
+    <version>1.1.1.2</version>
     <modName>FS25_WorkplaceTriggers</modName>
 
     <title>

--- a/src/WorkplaceMasterHUDBridge.lua
+++ b/src/WorkplaceMasterHUDBridge.lua
@@ -30,6 +30,9 @@ end
 -- The WT HUD draw body. Same call the standalone FSBaseMission.draw hook makes;
 -- WorkplaceSystem:draw() self-guards on isInitialized and the HUD on client.
 function WorkplaceMasterHUDBridge.drawStack()
+    -- Suite hide: MasterHUD # key. No-op when MasterHUD absent.
+    local mh = (g_currentMission ~= nil and g_currentMission.masterHUD) or g_masterHUD
+    if mh ~= nil and mh.areHudsHidden ~= nil and mh:areHudsHidden() then return end
     if g_WorkplaceSystem ~= nil then
         g_WorkplaceSystem:draw()
     end
@@ -52,6 +55,23 @@ function WorkplaceMasterHUDBridge.register()
     if ok then
         WorkplaceMasterHUDBridge.active = true
         wtLog("Registered WT HUD with MasterHUD (single draw loop + menu-suspend)")
+        if hud.registerEditListener ~= nil then
+            hud:registerEditListener(WorkplaceMasterHUDBridge.HUD_ID, {
+                enter = function()
+                    local sys = g_WorkplaceSystem
+                    if sys ~= nil and sys.hud ~= nil and sys.hud.enterEditMode ~= nil then
+                        sys.hud:enterEditMode()
+                    end
+                end,
+                exit = function()
+                    local sys = g_WorkplaceSystem
+                    if sys ~= nil and sys.hud ~= nil and sys.hud.editMode
+                        and sys.hud.exitEditMode ~= nil then
+                        sys.hud:exitEditMode()
+                    end
+                end,
+            })
+        end
     else
         wtLog("MasterHUD registration failed: " .. tostring(err) .. " (using own draw hook)")
     end

--- a/src/integrations/WTNetworkSyncBridge.lua
+++ b/src/integrations/WTNetworkSyncBridge.lua
@@ -77,9 +77,36 @@ local function applyStateArray(arr)
     local i = 1
     local count = tonumber(arr[i]) or 0; i = i + 1
 
-    -- Clear existing triggers and rebuild from snapshot
-    sys.triggerManager:delete()
-    sys.triggerManager:initialize()
+    -- BUILD 17:59: an empty snapshot is not a reason to tear the manager down. NetworkSync
+    -- reapplies state on a 30s floor, and during a long join that turned into a loop of
+    -- delete + initialize + "Applied 0 trigger(s)" every half minute while the i3ds were
+    -- still streaming. delete() unsubscribes MessageCenter and destroys markers and
+    -- hotspots; initialize() resubscribes. Doing both to arrive back where we started is
+    -- pure load hitch.
+    --
+    -- Nothing to apply, and the manager is already up and empty: keep the settings line
+    -- below and leave. Nothing to apply and not yet initialized: initialize only, no
+    -- teardown of something that was never built. A snapshot with triggers in it still
+    -- rebuilds exactly as before, because that is a real change and the player needs it.
+    local mgr = sys.triggerManager
+    local alreadyEmpty = mgr.isInitialized == true
+        and (type(mgr.triggers) ~= "table" or next(mgr.triggers) == nil)
+
+    if count == 0 and alreadyEmpty then
+        if sys.settings then
+            sys.settings.wageMultiplier = tonumber(arr[i]) or sys.settings.wageMultiplier or 1.0
+        end
+        return
+    end
+
+    if count == 0 then
+        if not mgr.isInitialized then
+            mgr:initialize()
+        end
+    else
+        mgr:delete()
+        mgr:initialize()
+    end
 
     for _ = 1, count do
         local triggerData = {


### PR DESCRIPTION
## Summary
Pre-release candidate for the Realistic Farming suite (Aug 17-24, 2026). Trigger purpose designation, NetworkSync bridge, MasterHUD/SettingsHub/StateLedger bridges, admin-gated MP exploit fix, and Judith join improvements.

## Commits
- Merge PR #25: Skip empty workplace-trigger rebuilds during a long join
- Merge PR #24: chore leftover MasterHUD bridge
- Merge PR #23: docs one feature, one PR (Tyson's ruling)
- fix: admin guard for nil host, trigger id de-dup, rotY restore
- feat: trigger purpose designation (server-gated setter + getter, all four serialization surfaces)
- feat: add NetworkSync bridge, remove standalone MP event class
- fix: WTNetworkSyncBridge failed to compile, killing the bridge
- clear default input bindings per Input Convention B2
- fix: require admin for UPDATE_TRIGGER MP event (wage exploit)
- feat: bridge trigger state onto StateLedger (delegate-when-present)
- feat: bridge onto SettingsHub + MasterHUD (delegate-when-present)
- fix: add spam cooldown to workplace trigger activation (BL17)
- Fix multiplayer simultaneous shift bug by tracking shifts per client
- Lua 5.1 pre-commit gate added