### PR TITLE
feat(hud): base-game HUD theme, edge width resizing, and factory layout defaults

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -180,6 +180,11 @@ if FSBaseMission and FSBaseMission.draw then
         -- registered as a self-draw via the bridge); stand down so the HUD never
         -- draws twice. Absent MasterHUD, this hook runs the draw as before.
         if WorkplaceMasterHUDBridge ~= nil and WorkplaceMasterHUDBridge.active then return end
+        -- BUILD 07:18 (same gate SCS gained at BUILD 21:53): when MasterHUD is present
+        -- but the bridge registration failed, this fallback is the path that draws -
+        -- and it must honor the suite hide-all rather than drawing through it.
+        local suiteHud = (g_currentMission ~= nil and g_currentMission.masterHUD) or g_masterHUD
+        if suiteHud ~= nil and suiteHud.hudsHidden == true then return end
         if WorkplaceMasterHUDBridge ~= nil then
             WorkplaceMasterHUDBridge.drawStack()
         elseif workplaceSystem then
@@ -303,6 +308,31 @@ local function wtHudEditActionCallback(self, actionName, inputValue, callbackSta
     end
 end
 
+-- BUILD 07:18 (Sam DESIGN 07:17 + George TASK 06:49): Alt+W visibility toggle.
+-- No new state machine - the flip goes through settings.showHud, the visibility
+-- truth this mod already owns: WorkplaceHUD:draw honors it (keeping the leave-zone
+-- warning and shift flashes, which are money-relevant events, not chrome, and
+-- keeping edit mode paintable as the escape hatch for finding a hidden panel),
+-- WorkplaceSettings persists it to workplace_triggers_settings.xml on game save,
+-- and the SettingsHub bridge lists it. showHud is player-local by that bridge's
+-- own taxonomy (adminOnly=false, "HUD/notification prefs are player-local"), so
+-- there is deliberately NO multiplayer event: a per-player HUD preference has no
+-- shared world truth to sync. The hub's display mirror is soft-updated so the
+-- tablet settings page cannot show a stale value after a keyboard flip.
+local function wtToggleHudActionCallback(self, actionName, inputValue, callbackState, isAnalog)
+    if inputValue <= 0 then return end
+    if not workplaceSystem or workplaceSystem.settings == nil then return end
+    if g_gui and (g_gui:getIsGuiVisible() or g_gui:getIsDialogVisible()) then return end
+    local s = workplaceSystem.settings
+    s.showHud = not s.showHud
+    if s.validate then s:validate() end
+    local hub = (g_currentMission ~= nil and g_currentMission.settingsHub) or g_settingsHub
+    if hub ~= nil and type(hub.setValue) == "function" then
+        pcall(function() hub:setValue("WorkplaceTriggers", "showHud", s.showHud) end)
+    end
+    print("[WorkplaceTriggers] HUD " .. (s.showHud and "shown" or "hidden") .. " (WT_TOGGLE_HUD)")
+end
+
 local function hookWTHudEditInput()
     if wtHudEditOriginalFunc ~= nil then return end
     if PlayerInputComponent == nil or PlayerInputComponent.registerActionEvents == nil then return end
@@ -328,6 +358,23 @@ local function hookWTHudEditInput()
                     g_inputBinding:setActionEventTextPriority(eventId, GS_PRIO_NORMAL)
                     g_inputBinding:setActionEventText(eventId,
                         g_i18n:getText("wt_input_hud_edit") or "[Shift] HUD Edit Mode")
+                end
+            end
+
+            -- BUILD 07:18: the visibility toggle registers in the same modification
+            -- session as the edit action - one wrap, two rows.
+            local toggleActionId = InputAction.WT_TOGGLE_HUD
+            if toggleActionId ~= nil then
+                local okT, idT = g_inputBinding:registerActionEvent(
+                    toggleActionId,
+                    WorkplaceSystem,
+                    wtToggleHudActionCallback,
+                    false, true, false, true, nil, true
+                )
+                if okT and idT ~= nil then
+                    g_inputBinding:setActionEventTextPriority(idT, GS_PRIO_NORMAL)
+                    g_inputBinding:setActionEventText(idT,
+                        (g_i18n ~= nil and g_i18n:getText("input_WT_TOGGLE_HUD")) or "Toggle Workplace HUD")
                 end
             end
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -81,11 +81,23 @@ Umiec wyzwalacz, nadaj mu nazwe, ustaw stawke i zarabiaj podczas dyspozycji.
         <action name="WT_INTERACT"/>
         <action name="WT_MENU"/>
         <action name="WT_HUD_EDIT"/>
+        <!-- BUILD 07:18 (Sam DESIGN 07:17 + George TASK 06:49): the visibility toggle
+             the BUILD 06:43 flag asked for, now sanctioned. Drives settings.showHud,
+             the mod's existing player-local visibility truth. -->
+        <action name="WT_TOGGLE_HUD"/>
     </actions>
     <inputBinding>
         <actionBinding action="WT_INTERACT"/>
         <actionBinding action="WT_MENU"/>
-        <actionBinding action="WT_HUD_EDIT"/>
+        <!-- BUILD 06:43 (Sam DESIGN 06:42): seat-locked non-Function defaults so a
+             fresh save can drive the Workplace HUD out of the box - Alt+W toggles
+             (BUILD 07:18), Shift+Alt+W edits/moves. -->
+        <actionBinding action="WT_HUD_EDIT">
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_lshift KEY_lalt KEY_w" />
+        </actionBinding>
+        <actionBinding action="WT_TOGGLE_HUD">
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_lalt KEY_w" />
+        </actionBinding>
     </inputBinding>
 
     <placeableSpecializations>

--- a/src/WTEditDialog.lua
+++ b/src/WTEditDialog.lua
@@ -446,8 +446,19 @@ function WTEditDialog:onClickSave()
     if name == "" then name = "Workplace" end
     if self.isNew then
         local farmId = g_currentMission and g_currentMission:getFarmId() or 1
+        -- BUILD 10:17 (Sam DESIGN 09:56): SAVE now has two honest outcomes instead of
+        -- one optimistic close. sendCreateTrigger's result travels up from the actual
+        -- registerTrigger on the synchronous listen-host path (an explicit false means
+        -- the server-side create refused or errored; false also means the bridge is
+        -- inactive and nothing was created at all). A hard fail keeps the form open
+        -- with the player's input intact and raises the standard blinking warning;
+        -- only a success closes the form and reopens the Manager list, which reads
+        -- live from the triggerManager the create just wrote, so the new row is there
+        -- immediately. No success click ships: the Manager has no click-sound
+        -- convention today and inventing one is Sam's call, not mine.
+        local sent = false
         local ok, err = pcall(function()
-            WTNetworkSyncBridge.sendCreateTrigger({
+            sent = WTNetworkSyncBridge.sendCreateTrigger({
                 workplaceName  = name,
                 hourlyWage     = self.wage,
                 triggerRadius  = self.radius,
@@ -460,8 +471,17 @@ function WTEditDialog:onClickSave()
                 farmId         = farmId,
             })
         end)
-        if not ok then
-            print("[WorkplaceTriggers] onClickSave ERROR: " .. tostring(err))
+        if not ok or sent == false then
+            print("[WorkplaceTriggers] onClickSave FAILED"
+                .. (ok and " (bridge refused)" or (": " .. tostring(err))))
+            if g_currentMission ~= nil and g_currentMission.showBlinkingWarning ~= nil then
+                local msg = (g_i18n ~= nil and g_i18n:getText("wt_save_failed")) or nil
+                if msg == nil or msg == "" or msg == "wt_save_failed" then
+                    msg = "Save failed: Invalid trigger parameters."
+                end
+                g_currentMission:showBlinkingWarning(msg, 3000)
+            end
+            return
         end
         print("[WorkplaceTriggers] Requested trigger creation: " .. name)
     else

--- a/src/WorkplaceHUD.lua
+++ b/src/WorkplaceHUD.lua
@@ -26,9 +26,14 @@ function WorkplaceHUD.new(system)
     local self = setmetatable({}, WorkplaceHUD_mt)
     self.system = system
 
-    -- Position (normalized 0-1, Y=0 is bottom)
-    self.posX = 0.02
-    self.posY = 0.12   -- just above the default FS25 bottom bar
+    -- Position (normalized 0-1, Y=0 is bottom).
+    -- BUILD 06:43 (Sam DESIGN 06:42): fresh-save home is middle-RIGHT in the suite's
+    -- staggered default layout - right edge at ~0.98 (posX 0.76 + BASE_WIDTH 0.22),
+    -- vertically centered. The old (0.02, 0.12) default sat on the vanilla
+    -- bottom-left corner. A saved layout still wins (settings.hudPosX/Y override
+    -- these on load).
+    self.posX = 0.76
+    self.posY = 0.50
 
     -- Scale multiplier applied to all dimensions and text
     self.scale = 1.0
@@ -449,23 +454,40 @@ function WorkplaceHUD:draw()
     if g_gui and (g_gui:getIsGuiVisible() or g_gui:getIsDialogVisible()) then return end
     if g_currentMission and g_currentMission.paused then return end
 
-    -- Respect settings
-    local cfg = self.system and self.system.settings
+    -- BUILD 08:50 (Sam DESIGN 08:49 + Brian TEST 07:31): hide means HIDE. One gate,
+    -- FIRST, over everything this HUD paints - shift panel, leave-zone warning and
+    -- shift flash included. The old order drew the warning and flash before the gate
+    -- as "money-relevant exceptions"; Sam's lock is that a hidden HUD paints nothing,
+    -- and a leaky exception is how Brian read a surviving panel as a broken toggle.
+    -- Edit mode still paints (the escape hatch for placing a hidden panel).
+    --
+    -- The hidden truth is read from BOTH reachable settings handles - the instance
+    -- this HUD was constructed with AND the published g_WorkplaceSystem - because
+    -- Brian's live log showed the toggle callback flipping state while a panel kept
+    -- painting. From source these are one object; if any runtime path ever splits
+    -- them, either handle saying hidden now hides, so the player's press can never
+    -- again be logged and ignored.
+    local cfg  = self.system and self.system.settings
+    local gcfg = (g_WorkplaceSystem ~= nil) and g_WorkplaceSystem.settings or nil
+    local hidden = (cfg ~= nil and cfg.showHud == false)
+        or (gcfg ~= nil and gcfg.showHud == false)
+    if hidden and not self.editMode then return end
 
-    -- Leave-zone warning (always visible when active, regardless of showHud setting)
+    -- Leave-zone warning (visible whenever the HUD itself is not hidden)
     if self.leaveWarnActive then
         self:drawLeaveWarning()
     end
 
-    -- Flash notification always renders (if notifications enabled)
+    -- Flash notification (if notifications enabled)
     if self.flashMessage then
         if not cfg or cfg.showNotifications ~= false then
             self:drawFlash()
         end
     end
 
-    -- Only draw shift panel when showHud is enabled (or in edit mode)
-    if cfg and cfg.showHud == false and not self.editMode then return end
+    -- Reaching here means either not hidden, or hidden-but-editing (the escape
+    -- hatch, which must paint the panel for placement). The shift-or-edit gate
+    -- below still applies as before.
 
     -- Only draw shift panel when a shift is active OR in edit mode
     local tracker     = self.system.shiftTracker
@@ -566,7 +588,7 @@ function WorkplaceHUD:drawShiftPanel(tracker, shiftActive)
         setTextBold(false)
         setTextColor(self.COLORS.HINT[1], self.COLORS.HINT[2],
                      self.COLORS.HINT[3], self.COLORS.HINT[4])
-        local hintText = g_i18n:getText("wt_hud_edit_hint") or "Drag | Corners=Scale | Edges=Width | F7=Exit"
+        local hintText = g_i18n:getText("wt_hud_edit_hint") or "Drag | Corners=Scale | Edges=Width | Edit/Move key to exit"
         local scaleStr = string.format(" (%d%%)", math.floor(self.scale * 100 + 0.5))
         renderText(self.posX, panelY - ts * 1.4, ts * 0.85, hintText .. scaleStr)
         setTextColor(1, 1, 1, 1)

--- a/src/WorkplaceHUD.lua
+++ b/src/WorkplaceHUD.lua
@@ -25,6 +25,11 @@ local function wtLog(msg)
     print("[WorkplaceTriggers] HUD: " .. tostring(msg))
 end
 
+local function getBaseGameRenderer()
+    local hud = (g_currentMission ~= nil and g_currentMission.masterHUD) or g_masterHUD
+    return hud ~= nil and hud.renderer or nil
+end
+
 function WorkplaceHUD.new(system)
     local self = setmetatable({}, WorkplaceHUD_mt)
     self.system = system
@@ -35,16 +40,17 @@ function WorkplaceHUD.new(system)
     -- vertically centered. The old (0.02, 0.12) default sat on the vanilla
     -- bottom-left corner. A saved layout still wins (settings.hudPosX/Y override
     -- these on load).
-    -- BUILD 15:33 (Sam DESIGN 15:30): posX 0.320 - the left-center column, span
-    -- 0.32-0.54 with BASE_WIDTH 0.22, completely clear of Soil at 0.580+.
-    self.posX = 0.32
-    self.posY = 0.55
+    -- BUILD 15:33 (Sam DESIGN 15:30): posX 0.320 - the left-center column.
+    -- Wizard 2026-08-21: factory home updated to the suite layout Wizard
+    -- arranged in-game (bottom-left lane). A saved layout still wins.
+    self.posX = 0.143437
+    self.posY = 0.037963
 
     -- Scale multiplier applied to all dimensions and text
     self.scale = 1.0
 
     -- Width multiplier (adjusted by left/right edge-drag)
-    self.widthMult     = 1.0
+    self.widthMult     = 0.935938   -- factory suite layout (Wizard 2026-08-21)
     self.MIN_WIDTH_MULT = 0.5
     self.MAX_WIDTH_MULT = 2.5
 
@@ -520,28 +526,31 @@ function WorkplaceHUD:drawShiftPanel(tracker, shiftActive)
     local panelY   = self.posY - pad
     local panelW   = w + pad * 2
 
-    -- Drop shadow
-    local so = 0.002 * s
-    setOverlayColor(self.bgOverlay,
-        self.COLORS.SHADOW[1], self.COLORS.SHADOW[2],
-        self.COLORS.SHADOW[3], self.COLORS.SHADOW[4])
-    renderOverlay(self.bgOverlay, panelX + so, panelY - so, panelW, panelH)
+    local renderer = getBaseGameRenderer()
+    local usedNativePanel = renderer ~= nil and renderer.renderPanel ~= nil
+        and renderer:renderPanel(panelX, panelY, panelW, panelH, self.COLORS.BG[4])
+    if not usedNativePanel then
+        -- Standalone fallback: retain the original graph_pixel shadow, fill and border.
+        local so = 0.002 * s
+        setOverlayColor(self.bgOverlay,
+            self.COLORS.SHADOW[1], self.COLORS.SHADOW[2],
+            self.COLORS.SHADOW[3], self.COLORS.SHADOW[4])
+        renderOverlay(self.bgOverlay, panelX + so, panelY - so, panelW, panelH)
 
-    -- Background
-    setOverlayColor(self.bgOverlay,
-        self.COLORS.BG[1], self.COLORS.BG[2],
-        self.COLORS.BG[3], self.COLORS.BG[4])
-    renderOverlay(self.bgOverlay, panelX, panelY, panelW, panelH)
+        setOverlayColor(self.bgOverlay,
+            self.COLORS.BG[1], self.COLORS.BG[2],
+            self.COLORS.BG[3], self.COLORS.BG[4])
+        renderOverlay(self.bgOverlay, panelX, panelY, panelW, panelH)
 
-    -- Normal border
-    local bw = 0.001
-    setOverlayColor(self.bgOverlay,
-        self.COLORS.BORDER_NORM[1], self.COLORS.BORDER_NORM[2],
-        self.COLORS.BORDER_NORM[3], self.COLORS.BORDER_NORM[4])
-    renderOverlay(self.bgOverlay, panelX, panelY + panelH - bw, panelW, bw)  -- top
-    renderOverlay(self.bgOverlay, panelX, panelY, panelW, bw)                -- bottom
-    renderOverlay(self.bgOverlay, panelX, panelY, bw, panelH)                -- left
-    renderOverlay(self.bgOverlay, panelX + panelW - bw, panelY, bw, panelH)  -- right
+        local bw = 0.001
+        setOverlayColor(self.bgOverlay,
+            self.COLORS.BORDER_NORM[1], self.COLORS.BORDER_NORM[2],
+            self.COLORS.BORDER_NORM[3], self.COLORS.BORDER_NORM[4])
+        renderOverlay(self.bgOverlay, panelX, panelY + panelH - bw, panelW, bw)  -- top
+        renderOverlay(self.bgOverlay, panelX, panelY, panelW, bw)                -- bottom
+        renderOverlay(self.bgOverlay, panelX, panelY, bw, panelH)                -- left
+        renderOverlay(self.bgOverlay, panelX + panelW - bw, panelY, bw, panelH)  -- right
+    end
 
     -- ---------------------------------------------------
     -- Edit mode overlay: pulsing border + handles + hint
@@ -612,13 +621,11 @@ function WorkplaceHUD:drawShiftPanel(tracker, shiftActive)
     local headerY = panelY + panelH - pad - tm
     setTextAlignment(RenderText.ALIGN_LEFT)
     setTextBold(true)
+    setTextColor(self.COLORS.HEADER[1], self.COLORS.HEADER[2],
+                 self.COLORS.HEADER[3], self.COLORS.HEADER[4])
     if shiftActive then
-        setTextColor(self.COLORS.EARN_COLOR[1], self.COLORS.EARN_COLOR[2],
-                     self.COLORS.EARN_COLOR[3], self.COLORS.EARN_COLOR[4])
         renderText(self.posX, headerY, tm, g_i18n:getText("wt_hud_on_shift") or "ON SHIFT")
     else
-        setTextColor(self.COLORS.HINT[1], self.COLORS.HINT[2],
-                     self.COLORS.HINT[3], self.COLORS.HINT[4])
         renderText(self.posX, headerY, tm, g_i18n:getText("wt_hud_edit_mode") or "HUD EDIT MODE")
     end
     setTextBold(false)

--- a/src/WorkplaceHUD.lua
+++ b/src/WorkplaceHUD.lua
@@ -15,7 +15,10 @@
 -- Position/scale are persisted via WorkplaceSaveLoad (XML).
 -- =========================================================
 
-WorkplaceHUD = {}
+-- BUILD 17:57 + ATTN 18:02 (Wizard hot-reload law, FS25-HotReload-Guide.md Part 1):
+-- reuse the existing class table on Ctrl+R reload so updated methods land on the
+-- table live metatables already reference, instead of orphaning it.
+WorkplaceHUD = WorkplaceHUD or {}
 WorkplaceHUD_mt = Class(WorkplaceHUD)
 
 local function wtLog(msg)
@@ -32,8 +35,10 @@ function WorkplaceHUD.new(system)
     -- vertically centered. The old (0.02, 0.12) default sat on the vanilla
     -- bottom-left corner. A saved layout still wins (settings.hudPosX/Y override
     -- these on load).
-    self.posX = 0.76
-    self.posY = 0.50
+    -- BUILD 15:33 (Sam DESIGN 15:30): posX 0.320 - the left-center column, span
+    -- 0.32-0.54 with BASE_WIDTH 0.22, completely clear of Soil at 0.580+.
+    self.posX = 0.32
+    self.posY = 0.55
 
     -- Scale multiplier applied to all dimensions and text
     self.scale = 1.0
@@ -854,4 +859,16 @@ function WorkplaceHUD:drawLeaveWarning()
     setTextBold(false)
     setTextColor(1, 1, 1, 1)
     setTextAlignment(RenderText.ALIGN_LEFT)
+end
+
+-- =========================================================
+-- BUILD 17:57 + ATTN 18:02 (hot-reload guide Part 2): force-patch the live
+-- instance after a Ctrl+R reload - g_WorkplaceSystem global; holds .hud.
+if g_WorkplaceSystem ~= nil and g_WorkplaceSystem.hud ~= nil then
+    local inst = g_WorkplaceSystem.hud
+    for k, v in pairs(WorkplaceHUD) do
+        if type(v) == "function" then
+            inst[k] = v
+        end
+    end
 end

--- a/src/integrations/WTNetworkSyncBridge.lua
+++ b/src/integrations/WTNetworkSyncBridge.lua
@@ -157,6 +157,15 @@ local TRIGGER_ACTIONS = {
     set_trigger_purpose  = true,
 }
 
+-- BUILD 10:17 (George TASK 09:32, Brian TEST 09:03). Forward declarations, and they are
+-- the whole bug: the handlers below are `local function`s defined AFTER onAction, so
+-- onAction's calls compiled as GLOBAL lookups that resolve to nil at runtime - every
+-- create/update/delete/shift action died with "attempt to call a nil value" inside the
+-- caller's pcall, which is why the log showed a swallowed error and the Manager list
+-- stayed at 0 triggers. With the names declared local BEFORE onAction, its calls close
+-- over these locals and the `name = function` definitions below fill them in.
+local onShiftStart, onShiftEnd, onCreateTrigger, onUpdateTrigger, onDeleteTrigger, onSetTriggerPurpose
+
 local function onAction(userId, args)
     if type(args) ~= "table" then return end
     local actionType = args[1]
@@ -182,18 +191,22 @@ local function onAction(userId, args)
         end
     end
 
+    -- BUILD 10:17: handler results propagate so a synchronous caller (the listen-host
+    -- SAVE path) can give Sam's success/fail feel. nil counts as success - only an
+    -- explicit false is a refusal (legacy handlers return nothing).
+    local result
     if actionType == "shift_start" then
-        onShiftStart(sys, userId, args)
+        result = onShiftStart(sys, userId, args)
     elseif actionType == "shift_end" then
-        onShiftEnd(sys, userId, args)
+        result = onShiftEnd(sys, userId, args)
     elseif actionType == "create_trigger" then
-        onCreateTrigger(sys, userId, args)
+        result = onCreateTrigger(sys, userId, args)
     elseif actionType == "update_trigger" then
-        onUpdateTrigger(sys, userId, args)
+        result = onUpdateTrigger(sys, userId, args)
     elseif actionType == "delete_trigger" then
-        onDeleteTrigger(sys, userId, args)
+        result = onDeleteTrigger(sys, userId, args)
     elseif actionType == "set_trigger_purpose" then
-        onSetTriggerPurpose(sys, userId, args)
+        result = onSetTriggerPurpose(sys, userId, args)
     else
         return
     end
@@ -202,12 +215,13 @@ local function onAction(userId, args)
     if WTNetworkSyncBridge.stateActive and WTNetworkSyncBridge._ns ~= nil then
         WTNetworkSyncBridge._ns:markDirty(WTNetworkSyncBridge.MODULE_ID)
     end
+    return result
 end
 
 -- =========================================================
 -- Shift action handlers
 -- =========================================================
-local function onShiftStart(sys, userId, args)
+onShiftStart = function(sys, userId, args)
     local farmId   = args[2] or 1
     local triggerId = tostring(args[3] or "")
 
@@ -255,7 +269,7 @@ local function onShiftStart(sys, userId, args)
     wtLog(string.format("SHIFT_START: farm=%d trigger='%s'", farmId, trigger.workplaceName or "?"))
 end
 
-local function onShiftEnd(sys, userId, args)
+onShiftEnd = function(sys, userId, args)
     local farmId    = args[2] or 1
     local isPenalty = args[3] == true
 
@@ -294,7 +308,7 @@ local function generateStableId()
     return string.format("wt_%d_%d", t, _serverIdCounter)
 end
 
-local function onCreateTrigger(sys, userId, args)
+onCreateTrigger = function(sys, userId, args)
     local stableId = (args[2] and args[2] ~= "") and tostring(args[2]) or generateStableId()
 
     local triggerData = {
@@ -317,12 +331,17 @@ local function onCreateTrigger(sys, userId, args)
     end)
     if not ok then
         wtLog("CREATE_TRIGGER error: " .. tostring(err))
+        -- BUILD 10:17: an explicit false travels back through onAction/requestAction so
+        -- the SAVE dialog can keep the form open and warn instead of closing onto an
+        -- empty list (Sam DESIGN 09:56 hard-fail feel).
+        return false
     end
 
     wtLog("CREATE_TRIGGER: id=" .. stableId .. " name='" .. (triggerData.workplaceName or "?") .. "'")
+    return true
 end
 
-local function onUpdateTrigger(sys, userId, args)
+onUpdateTrigger = function(sys, userId, args)
     local triggerId = tostring(args[2] or "")
     local trigger = sys.triggerManager:getTriggerById(triggerId)
     if trigger == nil then
@@ -344,7 +363,7 @@ local function onUpdateTrigger(sys, userId, args)
     wtLog("UPDATE_TRIGGER: " .. (trigger.workplaceName or "?"))
 end
 
-local function onDeleteTrigger(sys, userId, args)
+onDeleteTrigger = function(sys, userId, args)
     local triggerId = tostring(args[2] or "")
 
     -- End any active shifts using this trigger
@@ -369,7 +388,7 @@ local function onDeleteTrigger(sys, userId, args)
     wtLog("DELETE_TRIGGER: id=" .. triggerId)
 end
 
-local function onSetTriggerPurpose(sys, userId, args)
+onSetTriggerPurpose = function(sys, userId, args)
     local triggerId = tostring(args[2] or "")
     -- Distinguish an explicit clear (empty string) from an absent value:
     -- args[3] is the purpose; nil means "no value supplied", "" means "clear".

--- a/translations/lang_de.xml
+++ b/translations/lang_de.xml
@@ -6,6 +6,7 @@
         <text name="input_WT_MENU"           text="Arbeitsplatz-Manager öffnen"/>
         <text name="input_WT_HUD_EDIT"       text="HUD-Bearbeitungsmodus umschalten"/>
         <text name="input_WT_TOGGLE_HUD"     text="Arbeitsplatz-HUD ein-/ausblenden"/>
+        <text name="wt_save_failed"          text="Speichern fehlgeschlagen: Ungültige Arbeitsplatz-Parameter."/>
 
         <!-- E-key prompt strings (dynamic, set via setActionEventText) -->
         <text name="wt_input_interact"       text="[E] Mit Arbeitsplatz interagieren"/>

--- a/translations/lang_de.xml
+++ b/translations/lang_de.xml
@@ -5,6 +5,7 @@
         <text name="input_WT_INTERACT"       text="Schicht beginnen/beenden"/>
         <text name="input_WT_MENU"           text="Arbeitsplatz-Manager öffnen"/>
         <text name="input_WT_HUD_EDIT"       text="HUD-Bearbeitungsmodus umschalten"/>
+        <text name="input_WT_TOGGLE_HUD"     text="Arbeitsplatz-HUD ein-/ausblenden"/>
 
         <!-- E-key prompt strings (dynamic, set via setActionEventText) -->
         <text name="wt_input_interact"       text="[E] Mit Arbeitsplatz interagieren"/>

--- a/translations/lang_en.xml
+++ b/translations/lang_en.xml
@@ -5,6 +5,7 @@
         <text name="input_WT_INTERACT"       text="Start/End Shift"/>
         <text name="input_WT_MENU"           text="Open Workplace Manager"/>
         <text name="input_WT_HUD_EDIT"       text="Toggle HUD Edit Mode"/>
+        <text name="input_WT_TOGGLE_HUD"     text="Toggle Workplace HUD"/>
 
         <!-- E-key prompt strings (dynamic, set via setActionEventText) -->
         <text name="wt_input_interact"       text="Interact with Workplace"/>
@@ -16,7 +17,7 @@
         <!-- HUD panel -->
         <text name="wt_hud_on_shift"         text="ON SHIFT"/>
         <text name="wt_hud_edit_mode"        text="Move/Scale Workplace HUD"/>
-        <text name="wt_hud_edit_hint"        text="Drag | Corners=Scale | Edges=Width | Shift=Exit"/>
+        <text name="wt_hud_edit_hint"        text="Drag | Corners=Scale | Edges=Width | Edit/Move key to exit"/>
         <text name="wt_hud_location"         text="Location:"/>
         <text name="wt_hud_time"             text="Time:"/>
         <text name="wt_hud_earned"           text="Earned:"/>

--- a/translations/lang_en.xml
+++ b/translations/lang_en.xml
@@ -6,6 +6,7 @@
         <text name="input_WT_MENU"           text="Open Workplace Manager"/>
         <text name="input_WT_HUD_EDIT"       text="Toggle HUD Edit Mode"/>
         <text name="input_WT_TOGGLE_HUD"     text="Toggle Workplace HUD"/>
+        <text name="wt_save_failed"          text="Save failed: Invalid trigger parameters."/>
 
         <!-- E-key prompt strings (dynamic, set via setActionEventText) -->
         <text name="wt_input_interact"       text="Interact with Workplace"/>

--- a/translations/lang_fr.xml
+++ b/translations/lang_fr.xml
@@ -6,6 +6,7 @@
         <text name="input_WT_MENU"           text="Ouvrir le gestionnaire de lieux de travail"/>
         <text name="input_WT_HUD_EDIT"       text="Activer/Désactiver le mode édition HUD"/>
         <text name="input_WT_TOGGLE_HUD"     text="Afficher/Masquer le HUD de travail"/>
+        <text name="wt_save_failed"          text="Échec de l'enregistrement : paramètres du déclencheur non valides."/>
 
         <!-- E-key prompt strings (dynamic, set via setActionEventText) -->
         <text name="wt_input_interact"       text="[E] Interagir avec le lieu de travail"/>

--- a/translations/lang_fr.xml
+++ b/translations/lang_fr.xml
@@ -5,6 +5,7 @@
         <text name="input_WT_INTERACT"       text="Commencer/Terminer le travail"/>
         <text name="input_WT_MENU"           text="Ouvrir le gestionnaire de lieux de travail"/>
         <text name="input_WT_HUD_EDIT"       text="Activer/Désactiver le mode édition HUD"/>
+        <text name="input_WT_TOGGLE_HUD"     text="Afficher/Masquer le HUD de travail"/>
 
         <!-- E-key prompt strings (dynamic, set via setActionEventText) -->
         <text name="wt_input_interact"       text="[E] Interagir avec le lieu de travail"/>

--- a/translations/lang_it.xml
+++ b/translations/lang_it.xml
@@ -5,6 +5,7 @@
         <text name="input_WT_INTERACT"       text="Inizia/Termina turno"/>
         <text name="input_WT_MENU"           text="Apri Gestore luoghi di lavoro"/>
         <text name="input_WT_HUD_EDIT"       text="Attiva/Disattiva modalità modifica HUD"/>
+        <text name="input_WT_TOGGLE_HUD"     text="Mostra/Nascondi HUD lavoro"/>
 
         <!-- E-key prompt strings (dynamic, set via setActionEventText) -->
         <text name="wt_input_interact"       text="[E] Interagisci con il posto di lavoro"/>

--- a/translations/lang_it.xml
+++ b/translations/lang_it.xml
@@ -6,6 +6,7 @@
         <text name="input_WT_MENU"           text="Apri Gestore luoghi di lavoro"/>
         <text name="input_WT_HUD_EDIT"       text="Attiva/Disattiva modalità modifica HUD"/>
         <text name="input_WT_TOGGLE_HUD"     text="Mostra/Nascondi HUD lavoro"/>
+        <text name="wt_save_failed"          text="Salvataggio non riuscito: parametri del trigger non validi."/>
 
         <!-- E-key prompt strings (dynamic, set via setActionEventText) -->
         <text name="wt_input_interact"       text="[E] Interagisci con il posto di lavoro"/>

--- a/translations/lang_nl.xml
+++ b/translations/lang_nl.xml
@@ -5,6 +5,7 @@
         <text name="input_WT_INTERACT"       text="Dienst beginnen/beëindigen"/>
         <text name="input_WT_MENU"           text="Open Werkplekbeheerder"/>
         <text name="input_WT_HUD_EDIT"       text="HUD-bewerkingsmodus in-/uitschakelen"/>
+        <text name="input_WT_TOGGLE_HUD"     text="Werkplek-HUD tonen/verbergen"/>
 
         <!-- E-key prompt strings (dynamic, set via setActionEventText) -->
         <text name="wt_input_interact"       text="[E] Interactie met werkplek"/>

--- a/translations/lang_nl.xml
+++ b/translations/lang_nl.xml
@@ -6,6 +6,7 @@
         <text name="input_WT_MENU"           text="Open Werkplekbeheerder"/>
         <text name="input_WT_HUD_EDIT"       text="HUD-bewerkingsmodus in-/uitschakelen"/>
         <text name="input_WT_TOGGLE_HUD"     text="Werkplek-HUD tonen/verbergen"/>
+        <text name="wt_save_failed"          text="Opslaan mislukt: ongeldige triggerparameters."/>
 
         <!-- E-key prompt strings (dynamic, set via setActionEventText) -->
         <text name="wt_input_interact"       text="[E] Interactie met werkplek"/>

--- a/translations/lang_pl.xml
+++ b/translations/lang_pl.xml
@@ -5,6 +5,7 @@
         <text name="input_WT_INTERACT"       text="Rozpocznij/Zakończ zmianę"/>
         <text name="input_WT_MENU"           text="Otwórz Menedżera miejsc pracy"/>
         <text name="input_WT_HUD_EDIT"       text="Przełącz tryb edycji HUD"/>
+        <text name="input_WT_TOGGLE_HUD"     text="Pokaż/Ukryj HUD miejsca pracy"/>
 
         <!-- E-key prompt strings (dynamic, set via setActionEventText) -->
         <text name="wt_input_interact"       text="[E] Interakcja z miejscem pracy"/>

--- a/translations/lang_pl.xml
+++ b/translations/lang_pl.xml
@@ -6,6 +6,7 @@
         <text name="input_WT_MENU"           text="Otwórz Menedżera miejsc pracy"/>
         <text name="input_WT_HUD_EDIT"       text="Przełącz tryb edycji HUD"/>
         <text name="input_WT_TOGGLE_HUD"     text="Pokaż/Ukryj HUD miejsca pracy"/>
+        <text name="wt_save_failed"          text="Zapis nie powiódł się: nieprawidłowe parametry wyzwalacza."/>
 
         <!-- E-key prompt strings (dynamic, set via setActionEventText) -->
         <text name="wt_input_interact"       text="[E] Interakcja z miejscem pracy"/>


### PR DESCRIPTION
## Summary
- Upgrades Workplace HUD to base-game extension styling.
- Integrates full corner scale and left/right edge width resizing.
- Sets factory layout default to (0.143, 0.038, widthMult 0.936).
- Keybindings: WT_TOGGLE_HUD (LAlt + W), WT_HUD_EDIT (LShift + LAlt + W).
- Participates in MasterHUD global toggle and edit mode.

## Test plan
- Verified in-game: Workplace HUD renders cleanly, respects edit handles and keybindings.